### PR TITLE
Make simulator path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# CoB Simulation
+
+This repository contains a simple Flask API and utilities for running a Card of Binding simulation.
+
+## Configuration
+
+The application can load an external simulator module. Set the `SIMULATOR_PATH` environment variable to the directory containing your simulator. If the variable is provided, the path will be added to `sys.path` before importing the simulator.
+

--- a/app.py
+++ b/app.py
@@ -10,8 +10,12 @@ import datetime
 import traceback
 from collections import Counter
 import re # Added for parsing effect strings
-# Укажи путь к своему симулятору!
-sys.path.append(r"C:/Хранилище/Документы/DeckBuild/Cursor/Cob")
+
+# Append path to an external simulator if provided via environment variable
+SIMULATOR_ENV_VAR = "SIMULATOR_PATH"
+simulator_path = os.getenv(SIMULATOR_ENV_VAR)
+if simulator_path:
+    sys.path.append(simulator_path)
 from simulator import simulate_game, Card
 
 app = Flask(__name__)


### PR DESCRIPTION
## Summary
- allow overriding simulator path with the `SIMULATOR_PATH` environment variable
- document the new configuration option in README

## Testing
- `python -m py_compile app.py simulator.py interactive_game.py`

------
https://chatgpt.com/codex/tasks/task_e_6872dbb870948324b73a5ce890609cc8